### PR TITLE
Support ASP.NET Core 2.1 for net461 target

### DIFF
--- a/samples/TagHelperPack.Sample/TagHelperPack.Sample.csproj
+++ b/samples/TagHelperPack.Sample/TagHelperPack.Sample.csproj
@@ -14,15 +14,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp1.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Workaround for https://github.com/dotnet/sdk/issues/1488 -->
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/TagHelperPack/TagHelperPack.csproj
+++ b/src/TagHelperPack/TagHelperPack.csproj
@@ -20,12 +20,12 @@
     <PackageReference Include="Markdig" Version="0.15.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.0.4" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.0.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.0.6" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.1.*" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
The readme suggests that this package support ASP.NET Core 1.0.x, 1.1.x, and 2.1.x, so it seems to make sense to up the razor dependency so that the net461 target can depend on it too.