### PR TITLE
Add support for specifying a template name.

### DIFF
--- a/samples/TagHelperPack.Sample/Models/Order.cs
+++ b/samples/TagHelperPack.Sample/Models/Order.cs
@@ -10,6 +10,7 @@ namespace TagHelperPack.Sample.Models
     {
         public int Id { get; set; }
 
+        [Display(Name = "Placed By", Description = "The customer that placed the order.")]
         public Customer Customer { get; set; }
 
         public int CustomerId { get; set; }

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -31,6 +31,15 @@
     Use <code>&lt;label asp-for="..."&gt;</code> to include the model property's description in the <code>title</code>
     attribute.
 </p>
+<p>
+    When using <code>&lt;display for="..." /&gt;</code> or <code>&lt;editor for="..." /&gt;</code> use the
+    <code>template-name</code> attribute to override the template used to render the model.
+</p>
+<p>
+    When using <code>&lt;<em>any-element</em> asp-display-for="..."&gt;</code> or
+    <code>&lt;<em>any-element</em> asp-editor-for="..."&gt;</code> use the <code>asp-template-name</code> attribute to
+    override the template used to render the model.
+</p>
 <h4>Example</h4>
 <div class="panel panel-default">
     <div class="panel-body">
@@ -46,7 +55,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Customer.LastName"></label>
-                <editor for="Customer.LastName" />
+                <editor for="Customer.LastName" template-name="String2" />
                 <span asp-validation-for="Customer.LastName" class="text-danger"></span>
             </div>
             <div class="form-group">
@@ -59,6 +68,7 @@
                 <thead>
                     <tr>
                         <th asp-display-name-for="Customer.Orders[0].PlacedOn"></th>
+                        <th asp-display-name-for="Customer.Orders[0].Customer"></th>
                         <th asp-display-name-for="Customer.Orders[0].Total"></th>
                     </tr>
                 </thead>
@@ -67,6 +77,7 @@
                     {
                         <tr>
                             <td asp-display-for="@order.PlacedOn"></td>
+                            <td asp-display-for="@order.Customer" asp-template-name="CustomerName"></td>
                             <td asp-display-for="@order.Total"></td>
                         </tr>
                     }
@@ -93,7 +104,7 @@
     &lt;/div&gt;
     &lt;div class="form-group"&gt;
         &lt;label asp-for="LastName"&gt;&lt;/label&gt;
-        <strong>&lt;editor for="LastName" /&gt;</strong>
+        <strong>&lt;editor for="LastName" template-name="String2" /&gt;</strong>
         &lt;span asp-validation-for="LastName" class="text-danger"&gt;&lt;/span&gt;
     &lt;/div&gt;
     &lt;div class="form-group"&gt;
@@ -106,6 +117,7 @@
         &lt;thead&gt;
             &lt;tr&gt;
                 &lt;th <strong>asp-display-name-for="Orders[0].PlacedOn"&gt;</strong>&lt;/th&gt;
+                &lt;th <strong>asp-display-name-for="Orders[0].Customer"&gt;</strong>&lt;/th&gt;
                 &lt;th <strong>asp-display-name-for="Orders[0].Total"&gt;</strong>&lt;/th&gt;
             &lt;/tr&gt;
         &lt;/thead&gt;
@@ -114,6 +126,7 @@
             {
                 &lt;tr&gt;
                     &lt;td <strong>asp-display-for="@@order.PlacedOn"&gt;</strong>&lt;/td&gt;
+                    &lt;td <strong>asp-display-for="@@order.Customer" asp-template-name="CustomerName"&gt;</strong>&lt;/td&gt;
                     &lt;td <strong>asp-display-for="@@order.Total"&gt;</strong>&lt;/td&gt;
                 &lt;/tr&gt;
             }

--- a/samples/TagHelperPack.Sample/Views/Shared/DisplayTemplates/CustomerName.cshtml
+++ b/samples/TagHelperPack.Sample/Views/Shared/DisplayTemplates/CustomerName.cshtml
@@ -1,0 +1,3 @@
+@model TagHelperPack.Sample.Models.Customer
+
+<span>@Model.LastName, @Model.FirstName</span>

--- a/samples/TagHelperPack.Sample/Views/Shared/EditorTemplates/String2.cshtml
+++ b/samples/TagHelperPack.Sample/Views/Shared/EditorTemplates/String2.cshtml
@@ -1,0 +1,3 @@
+﻿@model string
+
+<input class="form-control" asp-for="@__model" style="font-weight: bold; color: blue;" />

--- a/src/TagHelperPack/DisplayForTagHelper.cs
+++ b/src/TagHelperPack/DisplayForTagHelper.cs
@@ -26,6 +26,12 @@ namespace TagHelperPack
         [HtmlAttributeName("asp-display-for")]
         public ModelExpression For { get; set; }
 
+        /// <summary>
+        /// The name of the template to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("asp-template-name")]
+        public string TemplateName { get; set; }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
@@ -34,7 +40,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.PostContent.AppendHtml(_htmlHelper.Display(For));
+            output.PostContent.AppendHtml(_htmlHelper.Display(For, TemplateName));
         }
     }
 }

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -26,6 +26,12 @@ namespace TagHelperPack
         [HtmlAttributeName("for")]
         public ModelExpression For { get; set; }
 
+        /// <summary>
+        /// The name of the template to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("template-name")]
+        public string TemplateName { get; set; }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
@@ -34,7 +40,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.Content.SetHtmlContent(_htmlHelper.Display(For));
+            output.Content.SetHtmlContent(_htmlHelper.Display(For, TemplateName));
 
             output.TagName = null;
         }

--- a/src/TagHelperPack/EditorForTagHelper.cs
+++ b/src/TagHelperPack/EditorForTagHelper.cs
@@ -26,6 +26,12 @@ namespace TagHelperPack
         [HtmlAttributeName("asp-editor-for")]
         public ModelExpression For { get; set; }
 
+        /// <summary>
+        /// The name of the template to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("asp-template-name")]
+        public string TemplateName { get; set; }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
@@ -34,7 +40,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.PostContent.AppendHtml(_htmlHelper.Editor(For));
+            output.PostContent.AppendHtml(_htmlHelper.Editor(For, TemplateName));
         }
     }
 }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -26,6 +26,12 @@ namespace TagHelperPack
         [HtmlAttributeName("for")]
         public ModelExpression For { get; set; }
 
+        /// <summary>
+        /// The name of the template to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("template-name")]
+        public string TemplateName { get; set; }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
@@ -34,7 +40,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.Content.SetHtmlContent(_htmlHelper.Editor(For));
+            output.Content.SetHtmlContent(_htmlHelper.Editor(For, TemplateName));
 
             output.TagName = null;
         }

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         private static Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent> _getDisplayThunk;
 
-        public static IHtmlContent Display(this IHtmlHelper htmlHelper, ModelExpression modelExpression)
+        public static IHtmlContent Display(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string templateName = null)
         {
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
@@ -47,15 +47,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _getDisplayThunk = (Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>));
                 }
 
-                return _getDisplayThunk(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name), null, null);
+                return _getDisplayThunk(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name), templateName, null);
             }
 
-            return htmlHelper.Display(GetExpressionText(modelExpression.Name));
+            return htmlHelper.Display(GetExpressionText(modelExpression.Name), templateName);
         }
 
         private static Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent> _editorThunk;
 
-        public static IHtmlContent Editor(this IHtmlHelper htmlHelper, ModelExpression modelExpression)
+        public static IHtmlContent Editor(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string templateName = null)
         {
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
@@ -66,10 +66,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _editorThunk = (Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>));
                 }
 
-                return _editorThunk(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name), null, null);
+                return _editorThunk(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name), templateName, null);
             }
 
-            return htmlHelper.Editor(GetExpressionText(modelExpression.Name));
+            return htmlHelper.Editor(GetExpressionText(modelExpression.Name), templateName);
         }
     }
 }


### PR DESCRIPTION
The Display Template HTML helpers support specifying a template name that is used to override the default display/editor template for a given type.

This adds support for that to the `display` and `editor` tag helpers.

This PR only adds this to `DisplayTagHelper` and `EditorTagHelper`. If you like this change, I can also add support for `DisplayForTagHelper` and `EditorForTagHelper`. The only question there is what should the attribute name be for those tag helpers? `template-name` like it is for `DisplayTagHelper` or `asp-template-name`? I'm assuming the latter to be consistent.