### PR TITLE
Add support for `html-field-name` + optional `IModelHtmlHelper` optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Supports ASP.NET Core 3.1.x, 5.0.x, and 6.0.x. Also supports ASP.NET Core 2.1.x 
     ```
    @addTagHelper *, TagHelperPack
     ```
+1. Optional: Register optimizations in `ConfigureServices()` or `Program.cs` (ASP.NET Core 6+)
+    ```
+    services.AddTagHelperPack();
+    ```

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -32,13 +32,19 @@
     attribute.
 </p>
 <p>
-    When using <code>&lt;display for="..." /&gt;</code> or <code>&lt;editor for="..." /&gt;</code> use the
-    <code>template-name</code> attribute to override the template used to render the model.
+    When using <code>&lt;display for="..." /&gt;</code> or <code>&lt;editor for="..." /&gt;</code>:
+    <ul>
+        <li>Use the <code>template-name</code> attribute to override the template used to render the model.</li>
+        <li>Use the <code>html-field-name</code> attribute to override the HTML field name used to render the model.</li>
+    </ul>
 </p>
 <p>
     When using <code>&lt;<em>any-element</em> asp-display-for="..."&gt;</code> or
-    <code>&lt;<em>any-element</em> asp-editor-for="..."&gt;</code> use the <code>asp-template-name</code> attribute to
-    override the template used to render the model.
+    <code>&lt;<em>any-element</em> asp-editor-for="..."&gt;</code>:
+    <ul>
+        <li>Use the <code>asp-template-name</code> attribute to override the template used to render the model.</li>
+        <li>Use the <code>asp-html-field-name</code> attribute to override the HTML field name used to render the model.</li>
+    </ul>
 </p>
 <h4>Example</h4>
 <div class="panel panel-default">
@@ -55,8 +61,16 @@
             </div>
             <div class="form-group">
                 <label asp-for="Customer.LastName"></label>
+                (<code>template-name="String2"</code>)
                 <editor for="Customer.LastName" template-name="String2" />
                 <span asp-validation-for="Customer.LastName" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-display-name-for="Customer.LastName" for="CustomerLastName">
+                </label>
+                (<code>html-field-name="CustomerLastName"</code>)
+                <editor for="Customer.LastName" html-field-name="CustomerLastName" />
+                <span class="text-danger" data-valmsg-for="CustomerLastName"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Customer.BirthDate"></label>

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -61,16 +61,13 @@
             </div>
             <div class="form-group">
                 <label asp-for="Customer.LastName"></label>
-                (<code>template-name="String2"</code>)
                 <editor for="Customer.LastName" template-name="String2" />
                 <span asp-validation-for="Customer.LastName" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-display-name-for="Customer.LastName" for="CustomerLastName">
-                </label>
-                (<code>html-field-name="CustomerLastName"</code>)
+                <label asp-display-name-for="Customer.LastName" for="CustomerLastName"></label>
                 <editor for="Customer.LastName" html-field-name="CustomerLastName" />
-                <span class="text-danger" data-valmsg-for="CustomerLastName"></span>
+                <span asp-validation-for="Customer.LastName" data-valmsg-for="CustomerLastName" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Customer.BirthDate"></label>
@@ -120,6 +117,11 @@
         &lt;label asp-for="LastName"&gt;&lt;/label&gt;
         <strong>&lt;editor for="LastName" template-name="String2" /&gt;</strong>
         &lt;span asp-validation-for="LastName" class="text-danger"&gt;&lt;/span&gt;
+    &lt;/div&gt;
+    &lt;div class="form-group"&gt;
+        &lt;label <strong>asp-display-name-for="LastName"</strong> for="CustomerLastName"&gt;&lt;/label&gt;
+        <strong>&lt;editor for="LastName" html-field-name="CustomerLastName" /&gt;</strong>
+        &lt;span asp-validation-for="LastName" data-valmsg-for="CustomerLastName" class="text-danger"&gt;&lt;/span&gt;
     &lt;/div&gt;
     &lt;div class="form-group"&gt;
         &lt;label asp-for="BirthDate"&gt;&lt;/label&gt;

--- a/samples/TagHelperPack.Sample/Startup.cs
+++ b/samples/TagHelperPack.Sample/Startup.cs
@@ -36,6 +36,9 @@ namespace TagHelperPack.Sample
                 });
             });
 
+            // Optional optimizations to avoid Reflection
+            services.AddTagHelperPack();
+
 #if !NET471
             services.AddRazorPages();
 #else

--- a/src/TagHelperPack/DependencyInjection/TagHelperPackServiceCollectionExtensions.cs
+++ b/src/TagHelperPack/DependencyInjection/TagHelperPackServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using TagHelperPack.Internal;
+using TagHelperPack;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/TagHelperPack/DependencyInjection/TagHelperPackServiceCollectionExtensions.cs
+++ b/src/TagHelperPack/DependencyInjection/TagHelperPackServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using TagHelperPack.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions for TagHelperPack.
+    /// </summary>
+    public static class TagHelperPackServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Add optional services to optimize TagHelperPack.
+        /// <list type="bullet">
+        ///   <item>Registers <see cref="ModelHtmlHelper"/> as <see cref="IHtmlHelper"/> and <see cref="IModelHtmlHelper"/>.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <returns><paramref name="services"/></returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
+        public static IServiceCollection AddTagHelperPack(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddTransient<IHtmlHelper, ModelHtmlHelper>();
+            services.AddTransient<IModelHtmlHelper, ModelHtmlHelper>();
+
+            return services;
+        }
+    }
+}

--- a/src/TagHelperPack/DisplayForTagHelper.cs
+++ b/src/TagHelperPack/DisplayForTagHelper.cs
@@ -28,6 +28,12 @@ namespace TagHelperPack
         public ModelExpression For { get; set; }
 
         /// <summary>
+        /// The name of the HTML field to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("asp-html-field-name")]
+        public string HtmlFieldName { get; set; }
+
+        /// <summary>
         /// The name of the template to use instead of the default one.
         /// </summary>
         [HtmlAttributeName("asp-template-name")]
@@ -45,7 +51,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.PostContent.AppendHtml(_htmlHelper.Display(For, TemplateName));
+            output.PostContent.AppendHtml(_htmlHelper.Display(For, HtmlFieldName, TemplateName));
         }
     }
 }

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -28,6 +28,12 @@ namespace TagHelperPack
         public ModelExpression For { get; set; }
 
         /// <summary>
+        /// The name of the HTML field to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("html-field-name")]
+        public string HtmlFieldName { get; set; }
+
+        /// <summary>
         /// The name of the template to use instead of the default one.
         /// </summary>
         [HtmlAttributeName("template-name")]
@@ -45,7 +51,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.Content.SetHtmlContent(_htmlHelper.Display(For, TemplateName));
+            output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName));
 
             output.TagName = null;
         }

--- a/src/TagHelperPack/EditorForTagHelper.cs
+++ b/src/TagHelperPack/EditorForTagHelper.cs
@@ -28,6 +28,12 @@ namespace TagHelperPack
         public ModelExpression For { get; set; }
 
         /// <summary>
+        /// The name of the HTML field to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("asp-html-field-name")]
+        public string HtmlFieldName { get; set; }
+
+        /// <summary>
         /// The name of the template to use instead of the default one.
         /// </summary>
         [HtmlAttributeName("asp-template-name")]
@@ -45,7 +51,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.PostContent.AppendHtml(_htmlHelper.Editor(For, TemplateName));
+            output.PostContent.AppendHtml(_htmlHelper.Editor(For, HtmlFieldName, TemplateName));
         }
     }
 }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -28,6 +28,12 @@ namespace TagHelperPack
         public ModelExpression For { get; set; }
 
         /// <summary>
+        /// The name of the HTML field to use instead of the default one.
+        /// </summary>
+        [HtmlAttributeName("html-field-name")]
+        public string HtmlFieldName { get; set; }
+
+        /// <summary>
         /// The name of the template to use instead of the default one.
         /// </summary>
         [HtmlAttributeName("template-name")]
@@ -45,7 +51,7 @@ namespace TagHelperPack
         {
             ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-            output.Content.SetHtmlContent(_htmlHelper.Editor(For, TemplateName));
+            output.Content.SetHtmlContent(_htmlHelper.Editor(For, HtmlFieldName, TemplateName));
 
             output.TagName = null;
         }

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         public static string DisplayName(this IHtmlHelper htmlHelper, ModelExpression modelExpression)
         {
+            var expression = GetExpressionText(modelExpression.Name);
+
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
                 if (_getDisplayNameThunk == null)
@@ -26,16 +28,18 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _getDisplayNameThunk = (Func<HtmlHelper, ModelExplorer, string, string>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string>));
                 }
 
-                return _getDisplayNameThunk.Invoke(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name));
+                return _getDisplayNameThunk.Invoke(htmlHelperConcrete, modelExpression.ModelExplorer, expression);
             }
 
-            return htmlHelper.DisplayName(GetExpressionText(modelExpression.Name));
+            return htmlHelper.DisplayName(expression);
         }
 
         private static Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent> _getDisplayThunk;
 
         public static IHtmlContent Display(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string templateName = null)
         {
+            var expression = GetExpressionText(modelExpression.Name);
+
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
                 if (_getDisplayThunk == null)
@@ -45,16 +49,18 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _getDisplayThunk = (Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>));
                 }
 
-                return _getDisplayThunk(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name), templateName, null);
+                return _getDisplayThunk(htmlHelperConcrete, modelExpression.ModelExplorer, expression, templateName, null);
             }
 
-            return htmlHelper.Display(GetExpressionText(modelExpression.Name), templateName);
+            return htmlHelper.Display(expression, templateName);
         }
 
         private static Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent> _editorThunk;
 
         public static IHtmlContent Editor(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string templateName = null)
         {
+            var expression = GetExpressionText(modelExpression.Name);
+
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
                 if (_editorThunk == null)
@@ -64,10 +70,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _editorThunk = (Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>));
                 }
 
-                return _editorThunk(htmlHelperConcrete, modelExpression.ModelExplorer, GetExpressionText(modelExpression.Name), templateName, null);
+                return _editorThunk(htmlHelperConcrete, modelExpression.ModelExplorer, expression, templateName, null);
             }
 
-            return htmlHelper.Editor(GetExpressionText(modelExpression.Name), templateName);
+            return htmlHelper.Editor(expression, templateName);
         }
     }
 }

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Html;
-using TagHelperPack.Internal;
+using TagHelperPack;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         private static Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent> _getDisplayThunk;
 
-        public static IHtmlContent Display(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string templateName = null)
+        public static IHtmlContent Display(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string htmlFieldName = null, string templateName = null, object additionalViewData = null)
         {
             var expression = GetExpressionText(modelExpression.Name);
 
@@ -49,15 +49,16 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _getDisplayThunk = (Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>));
                 }
 
-                return _getDisplayThunk(htmlHelperConcrete, modelExpression.ModelExplorer, expression, templateName, null);
+                return _getDisplayThunk(htmlHelperConcrete, modelExpression.ModelExplorer,
+                    htmlFieldName ?? expression, templateName, additionalViewData);
             }
 
-            return htmlHelper.Display(expression, templateName);
+            return htmlHelper.Display(expression, templateName, htmlFieldName, additionalViewData);
         }
 
         private static Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent> _editorThunk;
 
-        public static IHtmlContent Editor(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string templateName = null)
+        public static IHtmlContent Editor(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string htmlFieldName = null, string templateName = null, object additionalViewData = null)
         {
             var expression = GetExpressionText(modelExpression.Name);
 
@@ -70,10 +71,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     _editorThunk = (Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>)methodInfo.CreateDelegate(typeof(Func<HtmlHelper, ModelExplorer, string, string, object, IHtmlContent>));
                 }
 
-                return _editorThunk(htmlHelperConcrete, modelExpression.ModelExplorer, expression, templateName, null);
+                return _editorThunk(htmlHelperConcrete, modelExpression.ModelExplorer,
+                    htmlFieldName ?? expression, templateName, additionalViewData);
             }
 
-            return htmlHelper.Editor(expression, templateName);
+            return htmlHelper.Editor(expression, templateName, htmlFieldName, additionalViewData);
         }
     }
 }

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Html;
+using TagHelperPack.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
@@ -18,6 +19,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         public static string DisplayName(this IHtmlHelper htmlHelper, ModelExpression modelExpression)
         {
             var expression = GetExpressionText(modelExpression.Name);
+
+            if (htmlHelper is IModelHtmlHelper modelHtmlHelper)
+            {
+                return modelHtmlHelper.GenerateDisplayName(modelExpression.ModelExplorer, expression);
+            }
 
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
@@ -40,6 +46,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         {
             var expression = GetExpressionText(modelExpression.Name);
 
+            if (htmlHelper is IModelHtmlHelper modelHtmlHelper)
+            {
+                return modelHtmlHelper.GenerateDisplay(modelExpression.ModelExplorer,
+                    htmlFieldName ?? expression, templateName, additionalViewData);
+            }
+
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {
                 if (_getDisplayThunk == null)
@@ -61,6 +73,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         public static IHtmlContent Editor(this IHtmlHelper htmlHelper, ModelExpression modelExpression, string htmlFieldName = null, string templateName = null, object additionalViewData = null)
         {
             var expression = GetExpressionText(modelExpression.Name);
+
+            if (htmlHelper is IModelHtmlHelper modelHtmlHelper)
+            {
+                return modelHtmlHelper.GenerateEditor(modelExpression.ModelExplorer,
+                    htmlFieldName ?? expression, templateName, additionalViewData);
+            }
 
             if (htmlHelper is HtmlHelper htmlHelperConcrete)
             {

--- a/src/TagHelperPack/IModelHtmlHelper.cs
+++ b/src/TagHelperPack/IModelHtmlHelper.cs
@@ -10,12 +10,27 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 #endif
 
-namespace TagHelperPack.Internal
+namespace TagHelperPack
 {
+    /// <summary>
+    /// An <see cref="IHtmlHelper"/> with methods to generate HTML from a model.
+    /// </summary>
+    public interface IModelHtmlHelper : IHtmlHelper
+    {
+        /// <inheritdoc cref="HtmlHelper.GenerateDisplay(ModelExplorer, string, string, object)"/>
+        IHtmlContent GenerateDisplay(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData);
+
+        /// <inheritdoc cref="HtmlHelper.GenerateDisplayName(ModelExplorer, string)"/>
+        string GenerateDisplayName(ModelExplorer modelExplorer, string expression);
+
+        /// <inheritdoc cref="HtmlHelper.GenerateEditor(ModelExplorer, string, string, object)"/>
+        IHtmlContent GenerateEditor(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData);
+    }
+
     /// <summary>
     /// An <see cref="HtmlHelper"/> that implements <see cref="IModelHtmlHelper"/>.
     /// </summary>
-    public class ModelHtmlHelper : HtmlHelper, IModelHtmlHelper
+    internal class ModelHtmlHelper : HtmlHelper, IModelHtmlHelper
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelHtmlHelper"/> class.
@@ -37,20 +52,5 @@ namespace TagHelperPack.Internal
         /// <inheritdoc cref="HtmlHelper.GenerateEditor(ModelExplorer, string, string, object)"/>
         public new IHtmlContent GenerateEditor(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData)
             => base.GenerateEditor(modelExplorer, htmlFieldName, templateName, additionalViewData);
-    }
-
-    /// <summary>
-    /// An <see cref="IHtmlHelper"/> with methods to generate HTML from a model.
-    /// </summary>
-    public interface IModelHtmlHelper : IHtmlHelper
-    {
-        /// <inheritdoc cref="HtmlHelper.GenerateDisplay(ModelExplorer, string, string, object)"/>
-        IHtmlContent GenerateDisplay(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData);
-
-        /// <inheritdoc cref="HtmlHelper.GenerateDisplayName(ModelExplorer, string)"/>
-        string GenerateDisplayName(ModelExplorer modelExplorer, string expression);
-
-        /// <inheritdoc cref="HtmlHelper.GenerateEditor(ModelExplorer, string, string, object)"/>
-        IHtmlContent GenerateEditor(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData);
     }
 }

--- a/src/TagHelperPack/Internal/ModelHtmlHelper.cs
+++ b/src/TagHelperPack/Internal/ModelHtmlHelper.cs
@@ -1,0 +1,56 @@
+﻿using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+#if !NET471
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
+#else
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
+#endif
+
+namespace TagHelperPack.Internal
+{
+    /// <summary>
+    /// An <see cref="HtmlHelper"/> that implements <see cref="IModelHtmlHelper"/>.
+    /// </summary>
+    public class ModelHtmlHelper : HtmlHelper, IModelHtmlHelper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelHtmlHelper"/> class.
+        /// </summary>
+        /// <inheritdoc cref="HtmlHelper.HtmlHelper(IHtmlGenerator, ICompositeViewEngine, IModelMetadataProvider, IViewBufferScope, HtmlEncoder, UrlEncoder)"/>
+        public ModelHtmlHelper(IHtmlGenerator htmlGenerator, ICompositeViewEngine viewEngine, IModelMetadataProvider metadataProvider, IViewBufferScope bufferScope, HtmlEncoder htmlEncoder, UrlEncoder urlEncoder)
+            : base(htmlGenerator, viewEngine, metadataProvider, bufferScope, htmlEncoder, urlEncoder)
+        {
+        }
+
+        /// <inheritdoc cref="HtmlHelper.GenerateDisplay(ModelExplorer, string, string, object)"/>
+        public new IHtmlContent GenerateDisplay(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData)
+            => base.GenerateDisplay(modelExplorer, htmlFieldName, templateName, additionalViewData);
+
+        /// <inheritdoc cref="HtmlHelper.GenerateDisplayName(ModelExplorer, string)"/>
+        public new string GenerateDisplayName(ModelExplorer modelExplorer, string expression)
+            => base.GenerateDisplayName(modelExplorer, expression);
+
+        /// <inheritdoc cref="HtmlHelper.GenerateEditor(ModelExplorer, string, string, object)"/>
+        public new IHtmlContent GenerateEditor(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData)
+            => base.GenerateEditor(modelExplorer, htmlFieldName, templateName, additionalViewData);
+    }
+
+    /// <summary>
+    /// An <see cref="IHtmlHelper"/> with methods to generate HTML from a model.
+    /// </summary>
+    public interface IModelHtmlHelper : IHtmlHelper
+    {
+        /// <inheritdoc cref="HtmlHelper.GenerateDisplay(ModelExplorer, string, string, object)"/>
+        IHtmlContent GenerateDisplay(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData);
+
+        /// <inheritdoc cref="HtmlHelper.GenerateDisplayName(ModelExplorer, string)"/>
+        string GenerateDisplayName(ModelExplorer modelExplorer, string expression);
+
+        /// <inheritdoc cref="HtmlHelper.GenerateEditor(ModelExplorer, string, string, object)"/>
+        IHtmlContent GenerateEditor(ModelExplorer modelExplorer, string htmlFieldName, string templateName, object additionalViewData);
+    }
+}


### PR DESCRIPTION
Following on from https://github.com/DamianEdwards/TagHelperPack/pull/44 (cc @haacked):

1. Adds `display`/`editor` support for `html-field-name`
2. Adds `asp-display-for`/`asp-editor-for` support for `asp-html-field-name`
3. Also adds an optional `IModelHtmlHelper` optimization to avoid reflection.

![image](https://user-images.githubusercontent.com/133987/178134296-7e3695f9-4dae-4557-93db-1d663c7dba89.png)
