### PR TITLE
Display/Editor `view-data-*`

### DIFF
--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -151,18 +151,18 @@
         &lt;caption&gt;Customer Orders&lt;/caption&gt;
         &lt;thead&gt;
             &lt;tr&gt;
-                &lt;th <strong>asp-display-name-for="Orders[0].PlacedOn"&gt;</strong>&lt;/th&gt;
-                &lt;th <strong>asp-display-name-for="Orders[0].Customer"&gt;</strong>&lt;/th&gt;
-                &lt;th <strong>asp-display-name-for="Orders[0].Total"&gt;</strong>&lt;/th&gt;
+                &lt;th <strong>asp-display-name-for="Orders[0].PlacedOn"</strong>&gt;&lt;/th&gt;
+                &lt;th <strong>asp-display-name-for="Orders[0].Customer"</strong>&gt;&lt;/th&gt;
+                &lt;th <strong>asp-display-name-for="Orders[0].Total"</strong>&gt;&lt;/th&gt;
             &lt;/tr&gt;
         &lt;/thead&gt;
         &lt;tbody&gt;
             @@foreach (var order in Model.Orders)
             {
                 &lt;tr&gt;
-                    &lt;td <strong>asp-display-for="@@order.PlacedOn"&gt;</strong>&lt;/td&gt;
-                    &lt;td <strong>asp-display-for="@@order.Customer" asp-template-name="CustomerName"&gt;</strong>&lt;/td&gt;
-                    &lt;td <strong>asp-display-for="@@order.Total"&gt;</strong>&lt;/td&gt;
+                    &lt;td <strong>asp-display-for="@@order.PlacedOn"</strong>&gt;&lt;/td&gt;
+                    &lt;td <strong>asp-display-for="@@order.Customer" asp-template-name="CustomerName"</strong>&gt;&lt;/td&gt;
+                    &lt;td <strong>asp-display-for="@@order.Total"</strong>&gt;&lt;/td&gt;
                 &lt;/tr&gt;
             }
         &lt;/tbody&gt;

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -36,6 +36,7 @@
     <ul>
         <li>Use the <code>template-name</code> attribute to override the template used to render the model.</li>
         <li>Use the <code>html-field-name</code> attribute to override the HTML field name used to render the model.</li>
+        <li>Use <code>view-data-*</code> and <code>view-data</code> attributes to provide additional <code>ViewData</code> to the template.</li>
     </ul>
 </p>
 <p>
@@ -44,6 +45,7 @@
     <ul>
         <li>Use the <code>asp-template-name</code> attribute to override the template used to render the model.</li>
         <li>Use the <code>asp-html-field-name</code> attribute to override the HTML field name used to render the model.</li>
+        <li>Use <code>asp-view-data-*</code> and <code>asp-view-data</code> attributes to provide additional <code>ViewData</code> to the template.</li>
     </ul>
 </p>
 <p>
@@ -61,7 +63,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Customer.FirstName"></label>
-                <editor for="Customer.FirstName" />
+                <editor for="Customer.FirstName" view-data="@(new Dictionary<string, object>{ ["color"] = "red" })" view-data-font-style="@("italic")" />
                 <span asp-validation-for="Customer.FirstName" class="text-danger"></span>
             </div>
             <div class="form-group">
@@ -100,7 +102,7 @@
                     @foreach (var order in Model.Customer.Orders)
                     {
                         <tr>
-                            <td asp-display-for="@order.PlacedOn"></td>
+                            <td asp-display-for="@order.PlacedOn" asp-view-data-format="@("yyyy-MM-dd")"></td>
                             <td asp-display-for="@order.Customer" asp-template-name="CustomerName"></td>
                             <td asp-display-for="@order.Total"></td>
                         </tr>
@@ -123,7 +125,7 @@
     &lt;/div&gt;
     &lt;div class="form-group"&gt;
         &lt;label asp-for="FirstName"&gt;&lt;/label&gt;
-        <strong>&lt;editor for="FirstName" /&gt;</strong>
+        <strong>&lt;editor for="FirstName" view-data="@@(new Dictionary&lt;string, object&gt;{ ["color"] = "red" })" view-data-font-style="@@("italic")" /&gt;</strong>
         &lt;span asp-validation-for="FirstName" class="text-danger"&gt;&lt;/span&gt;
     &lt;/div&gt;
     &lt;div class="form-group"&gt;
@@ -160,7 +162,7 @@
             @@foreach (var order in Model.Orders)
             {
                 &lt;tr&gt;
-                    &lt;td <strong>asp-display-for="@@order.PlacedOn"</strong>&gt;&lt;/td&gt;
+                    &lt;td <strong>asp-display-for="@@order.PlacedOn" asp-view-data-format="@@("yyyy-MM-dd")"</strong>&gt;&lt;/td&gt;
                     &lt;td <strong>asp-display-for="@@order.Customer" asp-template-name="CustomerName"</strong>&gt;&lt;/td&gt;
                     &lt;td <strong>asp-display-for="@@order.Total"</strong>&gt;&lt;/td&gt;
                 &lt;/tr&gt;

--- a/samples/TagHelperPack.Sample/Views/Shared/DisplayTemplates/DateTime.cshtml
+++ b/samples/TagHelperPack.Sample/Views/Shared/DisplayTemplates/DateTime.cshtml
@@ -1,0 +1,3 @@
+@model DateTime
+
+@Model.ToString((string)ViewData["format"] ?? ViewData.ModelMetadata.DisplayFormatString)

--- a/samples/TagHelperPack.Sample/Views/Shared/EditorTemplates/String.cshtml
+++ b/samples/TagHelperPack.Sample/Views/Shared/EditorTemplates/String.cshtml
@@ -1,3 +1,9 @@
 ﻿@model string
 
-<input class="form-control" asp-for="@__model" />
+@{
+    var style = (ViewData["color"] is { } color ? $"color: {color};" : "")
+        + (ViewData["font-weight"] is { } fontWeight ? $"font-weight: {fontWeight};" : "")
+        + (ViewData["font-style"] is { } fontStyle ? $"font-style: {fontStyle};" : "");
+}
+
+<input class="form-control" asp-for="@__model" style="@style" />

--- a/src/TagHelperPack/DisplayForTagHelper.cs
+++ b/src/TagHelperPack/DisplayForTagHelper.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TagHelperPack;
 
@@ -11,7 +12,11 @@ namespace TagHelperPack;
 [HtmlTargetElement("*", Attributes = "asp-display-for")]
 public class DisplayForTagHelper : TagHelper
 {
+    private const string ViewDataDictionaryName = "asp-view-data";
+    private const string ViewDataPrefix = "asp-view-data-";
+
     private readonly IHtmlHelper _htmlHelper;
+    private IDictionary<string, object> _viewData;
 
     /// <summary>
     /// Creates a new instance of the <see cref="DisplayForTagHelper" /> class.
@@ -41,6 +46,16 @@ public class DisplayForTagHelper : TagHelper
     public string TemplateName { get; set; }
 
     /// <summary>
+    /// Additional view data.
+    /// </summary>
+    [HtmlAttributeName(ViewDataDictionaryName, DictionaryAttributePrefix = ViewDataPrefix)]
+    public IDictionary<string, object> ViewData
+    {
+        get => _viewData ??= new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        set => _viewData = value;
+    }
+
+    /// <summary>
     /// Gets or sets the <see cref="ViewContext"/>.
     /// </summary>
     [HtmlAttributeNotBound]
@@ -67,6 +82,6 @@ public class DisplayForTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        output.PostContent.AppendHtml(_htmlHelper.Display(For, HtmlFieldName, TemplateName));
+        output.PostContent.AppendHtml(_htmlHelper.Display(For, HtmlFieldName, TemplateName, ViewData));
     }
 }

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TagHelperPack;
 
@@ -11,7 +12,11 @@ namespace TagHelperPack;
 [HtmlTargetElement("display", Attributes = "for", TagStructure = TagStructure.WithoutEndTag)]
 public class DisplayTagHelper : TagHelper
 {
+    private const string ViewDataDictionaryName = "view-data";
+    private const string ViewDataPrefix = "view-data-";
+
     private readonly IHtmlHelper _htmlHelper;
+    private IDictionary<string, object> _viewData;
 
     /// <summary>
     /// Creates a new instance of the <see cref="DisplayNameTagHelper" /> class.
@@ -41,6 +46,16 @@ public class DisplayTagHelper : TagHelper
     public string TemplateName { get; set; }
 
     /// <summary>
+    /// Additional view data.
+    /// </summary>
+    [HtmlAttributeName(ViewDataDictionaryName, DictionaryAttributePrefix = ViewDataPrefix)]
+    public IDictionary<string, object> ViewData
+    {
+        get => _viewData ??= new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        set => _viewData = value;
+    }
+
+    /// <summary>
     /// Gets or sets the <see cref="ViewContext"/>.
     /// </summary>
     [HtmlAttributeNotBound]
@@ -67,7 +82,7 @@ public class DisplayTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName));
+        output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName, ViewData));
 
         output.TagName = null;
     }

--- a/src/TagHelperPack/EditorForTagHelper.cs
+++ b/src/TagHelperPack/EditorForTagHelper.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TagHelperPack;
 
@@ -11,7 +12,11 @@ namespace TagHelperPack;
 [HtmlTargetElement("*", Attributes = "asp-editor-for")]
 public class EditorForTagHelper : TagHelper
 {
+    private const string ViewDataDictionaryName = "asp-view-data";
+    private const string ViewDataPrefix = "asp-view-data-";
+
     private readonly IHtmlHelper _htmlHelper;
+    private IDictionary<string, object> _viewData;
 
     /// <summary>
     /// Creates a new instance of the <see cref="EditorForTagHelper" /> class.
@@ -41,6 +46,16 @@ public class EditorForTagHelper : TagHelper
     public string TemplateName { get; set; }
 
     /// <summary>
+    /// Additional view data.
+    /// </summary>
+    [HtmlAttributeName(ViewDataDictionaryName, DictionaryAttributePrefix = ViewDataPrefix)]
+    public IDictionary<string, object> ViewData
+    {
+        get => _viewData ??= new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        set => _viewData = value;
+    }
+
+    /// <summary>
     /// Gets or sets the <see cref="ViewContext"/>.
     /// </summary>
     [HtmlAttributeNotBound]
@@ -67,6 +82,6 @@ public class EditorForTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        output.PostContent.AppendHtml(_htmlHelper.Editor(For, HtmlFieldName, TemplateName));
+        output.PostContent.AppendHtml(_htmlHelper.Editor(For, HtmlFieldName, TemplateName, ViewData));
     }
 }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TagHelperPack;
 
@@ -11,7 +12,11 @@ namespace TagHelperPack;
 [HtmlTargetElement("editor", Attributes = "for", TagStructure = TagStructure.WithoutEndTag)]
 public class EditorTagHelper : TagHelper
 {
+    private const string ViewDataDictionaryName = "view-data";
+    private const string ViewDataPrefix = "view-data-";
+
     private readonly IHtmlHelper _htmlHelper;
+    private IDictionary<string, object> _viewData;
 
     /// <summary>
     /// Creates a new instance of the <see cref="EditorTagHelper" /> class.
@@ -41,6 +46,16 @@ public class EditorTagHelper : TagHelper
     public string TemplateName { get; set; }
 
     /// <summary>
+    /// Additional view data.
+    /// </summary>
+    [HtmlAttributeName(ViewDataDictionaryName, DictionaryAttributePrefix = ViewDataPrefix)]
+    public IDictionary<string, object> ViewData
+    {
+        get => _viewData ??= new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        set => _viewData = value;
+    }
+
+        /// <summary>
     /// Gets or sets the <see cref="ViewContext"/>.
     /// </summary>
     [HtmlAttributeNotBound]
@@ -67,7 +82,7 @@ public class EditorTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        output.Content.SetHtmlContent(_htmlHelper.Editor(For, HtmlFieldName, TemplateName));
+        output.Content.SetHtmlContent(_htmlHelper.Editor(For, HtmlFieldName, TemplateName, ViewData));
 
         output.TagName = null;
     }


### PR DESCRIPTION
- Resolves #48 

Works like  `<component param-*>`:
> * `<display for="Whatever" view-data-one="@("uno")" view-data-two="@("dos")" />`
> * `<div asp-display-for="Whatever" asp-view-data-one="@("uno")" asp-view-data-two="@("dos")" />`

Or you can provide an actual `IDictionary<string, object>` as `view-data`. Specifying both `view-data` and `view-data-*` merges the individual values into `view-data`.

### Initial Proposal (Not Supported)

Turns out simple string values (familiar from `asp-route-*`) don't work for `IDictionary<string, object>`?
> * `<display for="Whatever" view-data-one="uno" view-data-two="dos" />`
> * `<div asp-display-for="Whatever" asp-view-data-one="uno" asp-view-data-two="dos" />`

Anonymous object syntax isn't easy to support and it's not really idiomatic in Core anyway, so only passing a dictionary is allowed.
> * `<display for="Whatever" view-data="@(new { one = "uno" })" />`
> * `<div asp-display-for="Whatever" asp-view-data="@(new { one = "uno" })" />`

