### PR TITLE
Add for [asp-enabled]="boolean" for button, input, etc...

### DIFF
--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -58,6 +58,9 @@
     representing each of the values from the specified list. Set input elements to use the list using the <code>list</code> attribute,
     e.g. <code>&lt;input asp-for="..." list="countries" /&gt;&lt;datalist id="countries" asp-list="..."&gt;</code>
 </p>
+<p>
+    Use <code>&lt;button asp-enabled="..."&gt;</code> to disable/enable button
+</p>
 <h4>Example</h4>
 <div class="panel panel-default">
     <div class="panel-body">
@@ -118,6 +121,7 @@
             <div class="form-group">
                 <div class="text-danger" asp-validation-summary="All"></div>
                 <button type="submit" class="btn btn-primary">Save</button>
+                <button type="submit" class="btn btn-primary" asp-enabled="false">Disabled Button</button>
             </div>
         </form>
     </div>
@@ -179,6 +183,7 @@
     &lt;div class="form-group"&gt;
         &lt;div class="text-danger" asp-validation-summary="ModelOnly"&gt;&lt;/div&gt;
         &lt;button type="submit" class="btn btn-primary"&gt;Save&lt;/button&gt;
+        &lt;button type="submit" class="btn btn-primary" <strong>asp-enabled="false"</strong>&gt;Disabled Button&lt;/button&gt;
     &lt;/div&gt;
 &lt;/form&gt;</pre>
 </figure>

--- a/src/TagHelperPack/EnabledTagHelper.cs
+++ b/src/TagHelperPack/EnabledTagHelper.cs
@@ -17,7 +17,7 @@ namespace TagHelperPack;
 public class EnabledTagHelper : TagHelper
 {
     /// <summary>
-    /// Enabled this element when the condition is true. True by default.
+    /// Enable this element when the condition is <c>true</c>. Defaults to <c>true</c>.
     /// If enabled == false, it will add [disabled]="disabled" attribute to the element
     /// </summary>
     [HtmlAttributeName("asp-enabled")]

--- a/src/TagHelperPack/EnabledTagHelper.cs
+++ b/src/TagHelperPack/EnabledTagHelper.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TagHelperPack;
+
+/// <summary>
+/// Enable/Disable elements. Disabling by adding [disabled]="disabled" attribute to the element.
+/// Supported elements: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
+/// </summary>
+[HtmlTargetElement("button", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("fieldset", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("keygen", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("optgroup", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("option", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("select", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("textarea", Attributes = "[asp-enabled]")]
+[HtmlTargetElement("input", Attributes = "[asp-enabled]")]
+public class EnabledTagHelper : TagHelper
+{
+    /// <summary>
+    /// Enabled this element when the condition is true. True by default.
+    /// If enabled == false, it will add [disabled]="disabled" attribute to the element
+    /// </summary>
+    [HtmlAttributeName("asp-enabled")]
+    public bool IsEnabled { get; set; } = true;
+
+    /// <inheritdoc />
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (context.SuppressedByAspIf())
+        {
+            return;
+        }
+
+        // If it's not enabled
+        // Append disabled attribute
+        if (!IsEnabled)
+        {
+            output.Attributes.SetAttribute("disabled", "disabled");
+        }
+    }
+}

--- a/src/TagHelperPack/EnabledTagHelper.cs
+++ b/src/TagHelperPack/EnabledTagHelper.cs
@@ -3,7 +3,7 @@
 namespace TagHelperPack;
 
 /// <summary>
-/// Enable/Disable elements. Disabling by adding [disabled]="disabled" attribute to the element.
+/// Enable/disable elements. Disabling by adding <c>disabled="disabled"</c> attribute to the element.
 /// Supported elements: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
 /// </summary>
 [HtmlTargetElement("button", Attributes = "[asp-enabled]")]
@@ -18,7 +18,7 @@ public class EnabledTagHelper : TagHelper
 {
     /// <summary>
     /// Enable this element when the condition is <c>true</c>. Defaults to <c>true</c>.
-    /// If <c>false</c>, will add <c>[disabled]="disabled"</c> attribute to the element.
+    /// If <c>false</c>, will add <c>disabled="disabled"</c> attribute to the element.
     /// </summary>
     [HtmlAttributeName("asp-enabled")]
     public bool IsEnabled { get; set; } = true;
@@ -31,8 +31,7 @@ public class EnabledTagHelper : TagHelper
             return;
         }
 
-        // If it's not enabled
-        // Append disabled attribute
+        // If it's not enabled, append disabled attribute
         if (!IsEnabled)
         {
             output.Attributes.SetAttribute("disabled", "disabled");

--- a/src/TagHelperPack/EnabledTagHelper.cs
+++ b/src/TagHelperPack/EnabledTagHelper.cs
@@ -18,7 +18,7 @@ public class EnabledTagHelper : TagHelper
 {
     /// <summary>
     /// Enable this element when the condition is <c>true</c>. Defaults to <c>true</c>.
-    /// If enabled == false, it will add [disabled]="disabled" attribute to the element
+    /// If <c>false</c>, will add <c>[disabled]="disabled"</c> attribute to the element.
     /// </summary>
     [HtmlAttributeName("asp-enabled")]
     public bool IsEnabled { get; set; } = true;

--- a/tests/UnitTests/EnabledTagHelperTests.cs
+++ b/tests/UnitTests/EnabledTagHelperTests.cs
@@ -1,12 +1,70 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TagHelperPack;
+using Xunit;
 
 namespace UnitTests
 {
-    internal class EnabledTagHelperTests
+    public class EnabledTagHelperTests
     {
+        [Fact]
+        public void IsIntanceOf_TagHelper()
+        {
+            var helper = new EnabledTagHelper();
+
+            Assert.IsAssignableFrom<TagHelper>(helper);
+        }
+
+        [Fact]
+        public void IsEnabled_True_ByDefault()
+        {
+            var helper = new EnabledTagHelper();
+
+            Assert.True(helper.IsEnabled);
+        }
+
+        [Fact]
+        public void Process_AppendDisableAttribute_IfDisabled()
+        {
+            var list = new TagHelperAttributeList();
+
+            var context = new TagHelperContext("button", list, new Dictionary<object, object>(), "unqiueId");
+
+            var output = new TagHelperOutput("button", list, (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+            output.TagName = "button";
+            output.Content.SetHtmlContent("hello");
+
+            var helper = new EnabledTagHelper();
+            helper.IsEnabled = false;
+
+            helper.Process(context, output);
+
+            Assert.Equal("button", output.TagName);
+            Assert.True(output.Attributes.ContainsName("disabled"));
+        }
+
+        [Fact]
+        public void Process_WillNotAppendDisableAttribute_IfEnabled()
+        {
+            var list = new TagHelperAttributeList();
+
+            var context = new TagHelperContext("button", list, new Dictionary<object, object>(), "unqiueId");
+
+            var output = new TagHelperOutput("button", list, (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+            output.TagName = "button";
+            output.Content.SetHtmlContent("hello");
+
+            var helper = new EnabledTagHelper();
+            helper.IsEnabled = true;
+
+            helper.Process(context, output);
+
+            Assert.Equal("button", output.TagName);
+            Assert.False(output.Attributes.ContainsName("disabled"));
+        }
     }
 }

--- a/tests/UnitTests/EnabledTagHelperTests.cs
+++ b/tests/UnitTests/EnabledTagHelperTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    internal class EnabledTagHelperTests
+    {
+    }
+}

--- a/tests/UnitTests/EnabledTagHelperTests.cs
+++ b/tests/UnitTests/EnabledTagHelperTests.cs
@@ -27,8 +27,10 @@ namespace UnitTests
             Assert.True(helper.IsEnabled);
         }
 
-        [Fact]
-        public void Process_AppendDisableAttribute_IfDisabled()
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public void Process(bool isTagEnabled, bool containsDisabledAttribute)
         {
             var list = new TagHelperAttributeList();
 
@@ -39,32 +41,13 @@ namespace UnitTests
             output.Content.SetHtmlContent("hello");
 
             var helper = new EnabledTagHelper();
-            helper.IsEnabled = false;
+            helper.IsEnabled = isTagEnabled;
 
             helper.Process(context, output);
 
             Assert.Equal("button", output.TagName);
-            Assert.True(output.Attributes.ContainsName("disabled"));
+            Assert.Equal(containsDisabledAttribute, output.Attributes.ContainsName("disabled"));
         }
 
-        [Fact]
-        public void Process_WillNotAppendDisableAttribute_IfEnabled()
-        {
-            var list = new TagHelperAttributeList();
-
-            var context = new TagHelperContext("button", list, new Dictionary<object, object>(), "unqiueId");
-
-            var output = new TagHelperOutput("button", list, (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
-            output.TagName = "button";
-            output.Content.SetHtmlContent("hello");
-
-            var helper = new EnabledTagHelper();
-            helper.IsEnabled = true;
-
-            helper.Process(context, output);
-
-            Assert.Equal("button", output.TagName);
-            Assert.False(output.Attributes.ContainsName("disabled"));
-        }
     }
 }


### PR DESCRIPTION
Hello! I've been using this library for side project. Love it!

Add support for `<button asp-enabled="true|false"></button>` which will append `[disabled]="disabled"` attribute when `false`. Will not do anything if `true`.
Supported elements as defined here: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled

+ Added sample code
+ Unit tests