### PR TITLE
Add SuppressedByAspAuthz

### DIFF
--- a/src/TagHelperPack/DatalistTagHelper.cs
+++ b/src/TagHelperPack/DatalistTagHelper.cs
@@ -40,7 +40,7 @@ public class DatalistTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/DescriptionForTagHelper.cs
+++ b/src/TagHelperPack/DescriptionForTagHelper.cs
@@ -32,7 +32,7 @@ public sealed class DescriptionForTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/DisplayForTagHelper.cs
+++ b/src/TagHelperPack/DisplayForTagHelper.cs
@@ -75,7 +75,7 @@ public class DisplayForTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/DisplayNameForTagHelper.cs
+++ b/src/TagHelperPack/DisplayNameForTagHelper.cs
@@ -48,7 +48,7 @@ public class DisplayNameForTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/DisplayNameTagHelper.cs
+++ b/src/TagHelperPack/DisplayNameTagHelper.cs
@@ -48,7 +48,7 @@ public class DisplayNameTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -75,7 +75,7 @@ public class DisplayTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/EditorForTagHelper.cs
+++ b/src/TagHelperPack/EditorForTagHelper.cs
@@ -75,7 +75,7 @@ public class EditorForTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -75,7 +75,7 @@ public class EditorTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/EnabledTagHelper.cs
+++ b/src/TagHelperPack/EnabledTagHelper.cs
@@ -26,7 +26,7 @@ public class EnabledTagHelper : TagHelper
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/IfTagHelper.cs
+++ b/src/TagHelperPack/IfTagHelper.cs
@@ -19,7 +19,10 @@ public class IfTagHelper : TagHelper
     public bool Predicate { get; set; }
 
     /// <inheritdoc />
-    public override int Order => - 1;
+    // Run before other Tag Helpers (default Order is 0) so they can cooperatively decide not to run.
+    // Note this value is coordinated with the value of AuthzTagHelper.Order to ensure the IfTagHelper logic runs first.
+    // (Lower values run earlier).
+    public override int Order => - 100;
 
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
@@ -45,7 +48,7 @@ public class IfTagHelper : TagHelper
 /// <summary>
 /// Extension methods for <see cref="TagHelperContext"/>.
 /// </summary>
-public static class TagHelperContextExtensions
+public static class IfTagHelperContextExtensions
 {
     /// <summary>
     /// Determines if the <see cref="IfTagHelper"/> (<c>asp-if</c>) has suppressed rendering for the element associated with

--- a/src/TagHelperPack/LabelTitleTagHelper.cs
+++ b/src/TagHelperPack/LabelTitleTagHelper.cs
@@ -29,7 +29,7 @@ public class LabelTitleTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/MarkdownTagHelper.cs
+++ b/src/TagHelperPack/MarkdownTagHelper.cs
@@ -64,7 +64,7 @@ public class MarkdownTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }

--- a/src/TagHelperPack/RenderPartialTagHelper.cs
+++ b/src/TagHelperPack/RenderPartialTagHelper.cs
@@ -128,7 +128,7 @@ public class RenderPartialTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             // The asp-if Tag Helper has run already and determined this element shouldn't be rendered so just return now.
             output.SuppressOutput();

--- a/src/TagHelperPack/ScriptInliningTagHelper.cs
+++ b/src/TagHelperPack/ScriptInliningTagHelper.cs
@@ -60,7 +60,7 @@ public class ScriptInliningTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
-        if (context.SuppressedByAspIf())
+        if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;
         }


### PR DESCRIPTION
Tag Helpers can cooperatively determine if the AuthzTagHelper has suppressed the output of the current Tag Helper due to failing an authz check.

Fixes #62