### PR TITLE
Updates to display, editor and authz tag helpers

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "7.0.100",
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "allowPrerelease": false
   }
 }

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -337,7 +337,11 @@ public Customer Customer { get; set; }
 <figure>
     <pre>&lt;div asp-authz&gt;This will only render if the user is authenticated.&lt;/div&gt;
 &lt;div asp-authz="false"&gt;This will only render when the user is &lt;strong&gt;*not*&lt;/strong&gt; authenticated.&lt;/div&gt;
-&lt;div asp-authz-policy="AdminPolicy"&gt;This will only render if the user is authenticated and authorized via the "AdminPolicy" policy.&lt;/div&gt;</pre>
+&lt;div asp-authz-policy="AdminPolicy"&gt;This will only render if the user is authenticated and authorized via the "AdminPolicy" policy.&lt;/div&gt;
+&lt;div asp-authz-policy=&quot;PermissionPolicy&quot; asp-authz-permission=&quot;ViewUsers&quot;&gt;This will only render if the user has &quot;ViewUsers&quot; permission.&lt;/div&gt;
+&lt;div asp-authz-policy=&quot;PermissionPolicy&quot; asp-authz-permission=&quot;ManageUsers&quot;&gt;This will only render if the user has &quot;ManageUsers&quot; permission.&lt;/div&gt;
+&lt;div asp-authz-role=&quot;standard&quot;&gt;This will only render if the user belongs to the &quot;standard&quot; role.&lt;/div&gt;
+&lt;div asp-authz-role=&quot;admin&quot;&gt;This will only render if the user belongs to the &quot;admin&quot; role.&lt;/div&gt;</pre>
 </figure>
 
 <h3>If Tag Helper</h3>

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -327,6 +327,10 @@ public Customer Customer { get; set; }
         <div asp-authz>This will only render if the user is authenticated.</div>
         <div asp-authz="false">This will only render when the user is <strong>*not*</strong> authenticated.</div>
         <div asp-authz-policy="AdminPolicy">This will only render if the user is authenticated and authorized via the "AdminPolicy" policy.</div>
+        <div asp-authz-policy="PermissionPolicy" asp-authz-permission="ViewUsers">This will only render if the user has "ViewUsers" permission.</div>
+        <div asp-authz-policy="PermissionPolicy" asp-authz-permission="ManageUsers">This will only render if the user has "ManageUsers" permission.</div>
+        <div asp-authz-role="standard">This will only render if the user belongs to the "standard" role.</div>
+        <div asp-authz-role="admin">This will only render if the user belongs to the "admin" role.</div>
     </div>
 </div>
 <h4>Source</h4>

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -42,6 +42,9 @@
         <li>Use the <code>template-name</code> attribute to override the template used to render the model.</li>
         <li>Use the <code>html-field-name</code> attribute to override the HTML field name used to render the model.</li>
         <li>Use <code>view-data-*</code> and <code>view-data</code> attributes to provide additional <code>ViewData</code> to the template.</li>
+        <li>Use <code>view-data-htmlAttributes</code> attribute to add properties to the <code>htmlAttributes</code> property in <code>ViewData</code>. This property can then be used as an argument to <code>Html helpers</code> in the template to render it in the final html.</li>
+        <li>Use <code>class</code> and <code>style</code> attributes to add additional css classes or inline styles to the <code>htmlAttributes</code> property in <code>ViewData</code>.</li>
+        <li>Use <code>id</code> attribute to add the id property to the <code>htmlAttributes</code> property in <code>ViewData</code>.</li>
     </ul>
 </p>
 <p>
@@ -51,7 +54,7 @@
         <li>Use the <code>asp-template-name</code> attribute to override the template used to render the model.</li>
         <li>Use the <code>asp-html-field-name</code> attribute to override the HTML field name used to render the model.</li>
         <li>Use <code>asp-view-data-*</code> and <code>asp-view-data</code> attributes to provide additional <code>ViewData</code> to the template.</li>
-    </ul>
+   </ul>
 </p>
 <p>
     Use <code>&lt;datalist asp-list="..."&gt;</code> to render a <code>&lt;datalist&gt;</code> element containing <code>&lt;option&gt;</code> elements
@@ -77,6 +80,11 @@
             <div class="form-group">
                 <label asp-for="Customer.LastName"></label>
                 <editor for="Customer.LastName" template-name="String2" />
+                <span asp-validation-for="Customer.LastName" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Customer.LastName"></label>
+                <editor for="Customer.LastName" template-name="String3" id="myId" class="myClass" style="color: green" view-data-htmlAttributes='new {data_info = "some info"}' />
                 <span asp-validation-for="Customer.LastName" class="text-danger"></span>
             </div>
             <div class="form-group">
@@ -141,6 +149,11 @@
     &lt;div class="form-group"&gt;
         &lt;label asp-for="LastName"&gt;&lt;/label&gt;
         <strong>&lt;editor for="LastName" template-name="String2" /&gt;</strong>
+        &lt;span asp-validation-for="LastName" class="text-danger"&gt;&lt;/span&gt;
+    &lt;/div&gt;
+    &lt;div class="form-group"&gt;
+        &lt;label asp-for="LastName"&gt;&lt;/label&gt;
+        <strong>&lt;editor for="LastName" template-name="String3" id="myId" class="myClass" style="color: green" view-data-htmlAttributes='new {data_info = "some info"}' /&gt;</strong>
         &lt;span asp-validation-for="LastName" class="text-danger"&gt;&lt;/span&gt;
     &lt;/div&gt;
     &lt;div class="form-group"&gt;

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -327,8 +327,8 @@ public Customer Customer { get; set; }
         <div asp-authz>This will only render if the user is authenticated.</div>
         <div asp-authz="false">This will only render when the user is <strong>*not*</strong> authenticated.</div>
         <div asp-authz-policy="AdminPolicy">This will only render if the user is authenticated and authorized via the "AdminPolicy" policy.</div>
-        <div asp-authz-policy="PermissionPolicy" asp-authz-permission="ViewUsers">This will only render if the user has "ViewUsers" permission.</div>
-        <div asp-authz-policy="PermissionPolicy" asp-authz-permission="ManageUsers">This will only render if the user has "ManageUsers" permission.</div>
+        <div asp-authz-policy="PermissionPolicy" asp-authz-resource='"ViewUsers"'>This will only render if the user has "ViewUsers" permission.</div>
+        <div asp-authz-policy="PermissionPolicy" asp-authz-resource='"ManageUsers"'>This will only render if the user has "ManageUsers" permission.</div>
         <div asp-authz-role="standard">This will only render if the user belongs to the "standard" role.</div>
         <div asp-authz-role="admin">This will only render if the user belongs to the "admin" role.</div>
     </div>
@@ -338,8 +338,8 @@ public Customer Customer { get; set; }
     <pre>&lt;div asp-authz&gt;This will only render if the user is authenticated.&lt;/div&gt;
 &lt;div asp-authz="false"&gt;This will only render when the user is &lt;strong&gt;*not*&lt;/strong&gt; authenticated.&lt;/div&gt;
 &lt;div asp-authz-policy="AdminPolicy"&gt;This will only render if the user is authenticated and authorized via the "AdminPolicy" policy.&lt;/div&gt;
-&lt;div asp-authz-policy=&quot;PermissionPolicy&quot; asp-authz-permission=&quot;ViewUsers&quot;&gt;This will only render if the user has &quot;ViewUsers&quot; permission.&lt;/div&gt;
-&lt;div asp-authz-policy=&quot;PermissionPolicy&quot; asp-authz-permission=&quot;ManageUsers&quot;&gt;This will only render if the user has &quot;ManageUsers&quot; permission.&lt;/div&gt;
+&lt;div asp-authz-policy=&quot;PermissionPolicy&quot; asp-authz-resource='&quot;ViewUsers&quot;'&gt;This will only render if the user has &quot;ViewUsers&quot; permission.&lt;/div&gt;
+&lt;div asp-authz-policy=&quot;PermissionPolicy&quot; asp-authz-resource='&quot;ManageUsers&quot;'&gt;This will only render if the user has &quot;ManageUsers&quot; permission.&lt;/div&gt;
 &lt;div asp-authz-role=&quot;standard&quot;&gt;This will only render if the user belongs to the &quot;standard&quot; role.&lt;/div&gt;
 &lt;div asp-authz-role=&quot;admin&quot;&gt;This will only render if the user belongs to the &quot;admin&quot; role.&lt;/div&gt;</pre>
 </figure>

--- a/samples/TagHelperPack.Sample/QueryAuthScheme.cs
+++ b/samples/TagHelperPack.Sample/QueryAuthScheme.cs
@@ -28,10 +28,12 @@ public class QueryAuthScheme : AuthenticationHandler<AuthenticationSchemeOptions
         {
             identity.AddClaim(new Claim("Name", "AdminUser"));
             identity.AddClaim(new Claim("IsAdmin", "true"));
+            identity.AddClaim(new Claim(ClaimTypes.Role, "admin"));
         }
         else
         {
             identity.AddClaim(new Claim("Name", "StandardUser"));
+            identity.AddClaim(new Claim(ClaimTypes.Role, "standard"));
         }
         var user = new ClaimsPrincipal(identity);
         return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(user, nameof(QueryAuthScheme))));

--- a/samples/TagHelperPack.Sample/Startup.cs
+++ b/samples/TagHelperPack.Sample/Startup.cs
@@ -53,6 +53,25 @@ public class Startup
                     return httpContext is not null;
                 });
             });
+            options.AddPolicy("PermissionPolicy", policy =>
+            {
+                List<string> standardPermissions = new List<string>() { "ViewUsers"};
+                List<string> adminPermissions = new List<string>(standardPermissions) { "ManageUsers" };
+
+                policy.RequireAuthenticatedUser();
+                policy.RequireAssertion(handler =>
+                {
+                    var permission = handler.Resource as string;
+                    if (handler.User.IsInRole("admin"))
+                    {
+                        return adminPermissions.Contains(permission);
+                    }
+                    else //standard role
+                    {
+                        return standardPermissions.Contains(permission);
+                    }
+                });
+            });
         });
 
         // Optional optimizations to avoid Reflection

--- a/samples/TagHelperPack.Sample/Startup.cs
+++ b/samples/TagHelperPack.Sample/Startup.cs
@@ -55,8 +55,8 @@ public class Startup
             });
             options.AddPolicy("PermissionPolicy", policy =>
             {
-                List<string> standardPermissions = new List<string>() { "ViewUsers"};
-                List<string> adminPermissions = new List<string>(standardPermissions) { "ManageUsers" };
+                var standardPermissions = new List<string> { "ViewUsers" };
+                var adminPermissions = new List<string>(standardPermissions) { "ManageUsers" };
 
                 policy.RequireAuthenticatedUser();
                 policy.RequireAssertion(handler =>

--- a/samples/TagHelperPack.Sample/Views/Shared/EditorTemplates/String3.cshtml
+++ b/samples/TagHelperPack.Sample/Views/Shared/EditorTemplates/String3.cshtml
@@ -1,0 +1,18 @@
+﻿@model string
+
+@using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+@{
+    //default html attributes added by the template
+    var defaultHtmlAttributesObject = new
+    { 
+        Class = "form-control",
+        style= "font-weight: bold"
+    };
+
+    //merging the above html attributes with attributes received from the view
+    var viewHtmlAttributes = ViewData["htmlAttributes"] ?? new { };
+    var mergedHtmlAttributes = Html.MergeHtmlAttributesObjects(viewHtmlAttributes, defaultHtmlAttributesObject);
+}
+
+@Html.TextBox("", Model, mergedHtmlAttributes)

--- a/src/TagHelperPack/AuthzTagHelper.cs
+++ b/src/TagHelperPack/AuthzTagHelper.cs
@@ -60,7 +60,7 @@ public class AuthzTagHelper : TagHelper
     public string RequiredRole { get; set; }
 
     /// <summary>
-    /// A permission that must be satisfied in order for the current element to be rendered. asp-authz-policy should be set as well.
+    /// A permission that must be satisfied in order for the current element to be rendered. <c>asp-authz-policy</c> should be set as well.
     /// </summary>
     [HtmlAttributeName(AspAuthzPolicyPermissionAttributeName)]
     public string RequiredPolicyPermission { get; set; }

--- a/src/TagHelperPack/AuthzTagHelper.cs
+++ b/src/TagHelperPack/AuthzTagHelper.cs
@@ -85,6 +85,11 @@ public class AuthzTagHelper : TagHelper
             throw new ArgumentNullException(nameof(output));
         }
 
+        if(!string.IsNullOrEmpty(RequiredRole) && !string.IsNullOrEmpty(RequiredPolicy))
+        {
+            throw new InvalidOperationException($"{AspAuthzRoleAttributeName} and {AspAuthzPolicyAttributeName} cannot be set at the same time.");
+        }
+
         if (context.SuppressedByAspIf() || context.SuppressedByAspAuthz())
         {
             return;

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -62,6 +62,18 @@ public class DisplayTagHelper : TagHelper
     [ViewContext]
     public ViewContext ViewContext { get; set; }
 
+    /// <summary>
+    /// css class
+    /// </summary>
+    [HtmlAttributeName("class")]
+    public string Class { get; set; }
+
+    /// <summary>
+    /// css style
+    /// </summary>
+    [HtmlAttributeName("style")]
+    public string Style { get; set; }
+
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
@@ -82,7 +94,9 @@ public class DisplayTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName, ViewData));
+        var cssViewData = new { htmlAttributes = new { @class = Class, style = Style } };
+        var finalViewData = _htmlHelper.MergeHtmlAttributes(cssViewData, ViewData);
+        output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName, finalViewData));
 
         output.TagName = null;
     }

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -63,13 +63,13 @@ public class DisplayTagHelper : TagHelper
     public ViewContext ViewContext { get; set; }
 
     /// <summary>
-    /// css class
+    /// CSS class name.
     /// </summary>
     [HtmlAttributeName("class")]
     public string Class { get; set; }
 
     /// <summary>
-    /// css style
+    /// CSS inline style.
     /// </summary>
     [HtmlAttributeName("style")]
     public string Style { get; set; }

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -95,7 +95,7 @@ public class DisplayTagHelper : TagHelper
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
         var cssViewData = new { htmlAttributes = new { @class = Class, style = Style } };
-        var finalViewData = _htmlHelper.MergeHtmlAttributes(cssViewData, ViewData);
+        var finalViewData = _htmlHelper.MergeHtmlAttributesObjects(cssViewData, ViewData);
         output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName, finalViewData));
 
         output.TagName = null;

--- a/src/TagHelperPack/DisplayTagHelper.cs
+++ b/src/TagHelperPack/DisplayTagHelper.cs
@@ -74,6 +74,12 @@ public class DisplayTagHelper : TagHelper
     [HtmlAttributeName("style")]
     public string Style { get; set; }
 
+    /// <summary>
+    /// HTML id.
+    /// </summary>
+    [HtmlAttributeName("id")]
+    public string Id { get; set; }
+
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
@@ -94,9 +100,31 @@ public class DisplayTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        var cssViewData = new { htmlAttributes = new { @class = Class, style = Style } };
-        var finalViewData = _htmlHelper.MergeHtmlAttributesObjects(cssViewData, ViewData);
-        output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName, finalViewData));
+        //create a local htmlAttributes dictionary for html attributes exposed by the tag helper
+        IDictionary<string, object> htmlAttributes = new Dictionary<string, object>();
+        if (!string.IsNullOrWhiteSpace(Id))
+        {
+            htmlAttributes["id"] = Id;
+        }
+        if (!string.IsNullOrWhiteSpace(Class))
+        {
+            htmlAttributes["class"] = Class;
+        }
+        if (!string.IsNullOrWhiteSpace(Style))
+        {
+            htmlAttributes["style"] = Style;
+        }
+
+        //get the htmlAttributes property from tag ViewData
+        ViewData.TryGetValue("htmlAttributes", out var viewDataHtmlAttributes);
+
+        //merging local and ViewData htmlAttributes properties
+        htmlAttributes = _htmlHelper.MergeHtmlAttributesObjects(htmlAttributes, viewDataHtmlAttributes);
+
+        //setting the merged htmlAttributes on the ViewData of the tag.
+        ViewData["htmlAttributes"] = htmlAttributes;
+
+        output.Content.SetHtmlContent(_htmlHelper.Display(For, HtmlFieldName, TemplateName, ViewData));
 
         output.TagName = null;
     }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -55,12 +55,24 @@ public class EditorTagHelper : TagHelper
         set => _viewData = value;
     }
 
-        /// <summary>
+    /// <summary>
     /// Gets or sets the <see cref="ViewContext"/>.
     /// </summary>
     [HtmlAttributeNotBound]
     [ViewContext]
     public ViewContext ViewContext { get; set; }
+
+    /// <summary>
+    /// css class
+    /// </summary>
+    [HtmlAttributeName("class")]
+    public string Class { get; set; }
+
+    /// <summary>
+    /// css style
+    /// </summary>
+    [HtmlAttributeName("style")]
+    public string Style { get; set; }
 
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
@@ -82,7 +94,9 @@ public class EditorTagHelper : TagHelper
 
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
-        output.Content.SetHtmlContent(_htmlHelper.Editor(For, HtmlFieldName, TemplateName, ViewData));
+        var cssViewData = new { htmlAttributes = new { @class = Class, style = Style } };
+        var finalViewData = _htmlHelper.MergeHtmlAttributes(cssViewData, ViewData);
+        output.Content.SetHtmlContent(_htmlHelper.Editor(For, HtmlFieldName, TemplateName, finalViewData));
 
         output.TagName = null;
     }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -63,13 +63,13 @@ public class EditorTagHelper : TagHelper
     public ViewContext ViewContext { get; set; }
 
     /// <summary>
-    /// css class
+    /// CSS class name.
     /// </summary>
     [HtmlAttributeName("class")]
     public string Class { get; set; }
 
     /// <summary>
-    /// css style
+    /// CSS inline style.
     /// </summary>
     [HtmlAttributeName("style")]
     public string Style { get; set; }

--- a/src/TagHelperPack/EditorTagHelper.cs
+++ b/src/TagHelperPack/EditorTagHelper.cs
@@ -95,7 +95,7 @@ public class EditorTagHelper : TagHelper
         ((IViewContextAware)_htmlHelper).Contextualize(ViewContext);
 
         var cssViewData = new { htmlAttributes = new { @class = Class, style = Style } };
-        var finalViewData = _htmlHelper.MergeHtmlAttributes(cssViewData, ViewData);
+        var finalViewData = _htmlHelper.MergeHtmlAttributesObjects(cssViewData, ViewData);
         output.Content.SetHtmlContent(_htmlHelper.Editor(For, HtmlFieldName, TemplateName, finalViewData));
 
         output.TagName = null;

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -3,6 +3,9 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Html;
 using TagHelperPack;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
@@ -94,5 +97,59 @@ internal static class HtmlHelperExtensions
         }
 
         return htmlHelper.Editor(expression, templateName, htmlFieldName, additionalViewData);
+    }
+
+    /// <summary>
+    /// Merge values from 2 anonymous or IDictionary objects. Values of overlapping keys from the 'existing values' object are replaced by the values 
+    /// from the 'new values' object except if the keys are 'class' or 'style', in which case the values are concatentated with a space or ; respectively.
+    /// </summary>
+    /// <param name="newHtmlAttributesObject">new values</param>
+    /// <param name="existingHtmlAttributesObject">existing values</param>
+    /// <returns></returns>
+    internal static IDictionary<string, object> MergeHtmlAttributes(this IHtmlHelper helper, object newHtmlAttributesObject, object existingHtmlAttributesObject)
+    {
+        var keysConcatValuesWithSpace = new string[] { "class" };
+        var keysConcatValuesWithSemiColon = new string[] { "style" };
+
+        var htmlAttributesDict = newHtmlAttributesObject as IDictionary<string, object>;
+        var defaultHtmlAttributesDict = existingHtmlAttributesObject as IDictionary<string, object>;
+
+        IDictionary<string, object> htmlAttributes = (htmlAttributesDict != null)
+            ? new RouteValueDictionary(htmlAttributesDict)
+            : HtmlHelper.AnonymousObjectToHtmlAttributes(newHtmlAttributesObject);
+
+        IDictionary<string, object> existingHtmlAttributes = (defaultHtmlAttributesDict != null)
+            ? new RouteValueDictionary(defaultHtmlAttributesDict)
+            : HtmlHelper.AnonymousObjectToHtmlAttributes(existingHtmlAttributesObject);
+
+        foreach (var item in htmlAttributes)
+        {
+            if (keysConcatValuesWithSpace.Contains(item.Key))
+            {
+                existingHtmlAttributes.TryGetValue(item.Key, out object? value);
+                if (value != null && item.Value != null)
+                {
+                    existingHtmlAttributes[item.Key] = value != null ?
+                        string.Format("{0} {1}", existingHtmlAttributes[item.Key], item.Value)
+                        : item.Value;
+                }
+            }
+            else if (keysConcatValuesWithSemiColon.Contains(item.Key))
+            {
+                existingHtmlAttributes.TryGetValue(item.Key, out object? value);
+                if (value != null && item.Value != null)
+                {
+                    existingHtmlAttributes[item.Key] = value != null ?
+                        string.Format("{0}; {1}", existingHtmlAttributes[item.Key], item.Value)
+                        : item.Value;
+                }
+            }
+            else
+            {
+                existingHtmlAttributes[item.Key] = item.Value;
+            }
+        }
+
+        return existingHtmlAttributes;
     }
 }

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Reflection;
+﻿using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Html;
-using TagHelperPack;
+using Microsoft.AspNetCore.Routing;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Routing;
+using System.Reflection;
+using TagHelperPack;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -98,39 +98,4 @@ internal static class HtmlHelperExtensions
 
         return htmlHelper.Editor(expression, templateName, htmlFieldName, additionalViewData);
     }
-
-    /// <summary>
-    /// Merge values from 2 anonymous or IDictionary objects. Values of overlapping keys from the 'existing values' object are replaced by the values 
-    /// from the 'new values' object except if the keys are 'class' or 'style', in which case the values are concatentated with a space or ; respectively.
-    /// </summary>
-    /// <param name="newHtmlAttributesObject">new values</param>
-    /// <param name="existingHtmlAttributesObject">existing values</param>
-    /// <returns></returns>
-    internal static IDictionary<string, object> MergeHtmlAttributes(this IHtmlHelper helper, object newHtmlAttributesObject, object existingHtmlAttributesObject)
-    {
-        var keysConcatValuesWithSpace = new string[] { "class" };
-        var keysConcatValuesWithSemiColon = new string[] { "style" };
-
-        IDictionary<string, object> htmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(newHtmlAttributesObject);
-        IDictionary<string, object> existingHtmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(existingHtmlAttributesObject);
-
-        foreach (var item in htmlAttributes)
-        {
-            string separator = string.Empty;
-            if (keysConcatValuesWithSpace.Contains(item.Key))
-            {
-                separator = " ";
-            }
-            else if (keysConcatValuesWithSemiColon.Contains(item.Key))
-            {
-                separator = "; ";
-            }
-            existingHtmlAttributes.TryGetValue(item.Key, out object? value);
-            existingHtmlAttributes[item.Key] = value != null && !string.IsNullOrEmpty(separator) ?
-                    string.Format("{0}{1}{2}", existingHtmlAttributes[item.Key], separator, item.Value)
-                    : item.Value;
-        }
-
-        return existingHtmlAttributes;
-    }
 }

--- a/src/TagHelperPack/HtmlHelperExtensions.cs
+++ b/src/TagHelperPack/HtmlHelperExtensions.cs
@@ -111,43 +111,24 @@ internal static class HtmlHelperExtensions
         var keysConcatValuesWithSpace = new string[] { "class" };
         var keysConcatValuesWithSemiColon = new string[] { "style" };
 
-        var htmlAttributesDict = newHtmlAttributesObject as IDictionary<string, object>;
-        var defaultHtmlAttributesDict = existingHtmlAttributesObject as IDictionary<string, object>;
-
-        IDictionary<string, object> htmlAttributes = (htmlAttributesDict != null)
-            ? new RouteValueDictionary(htmlAttributesDict)
-            : HtmlHelper.AnonymousObjectToHtmlAttributes(newHtmlAttributesObject);
-
-        IDictionary<string, object> existingHtmlAttributes = (defaultHtmlAttributesDict != null)
-            ? new RouteValueDictionary(defaultHtmlAttributesDict)
-            : HtmlHelper.AnonymousObjectToHtmlAttributes(existingHtmlAttributesObject);
+        IDictionary<string, object> htmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(newHtmlAttributesObject);
+        IDictionary<string, object> existingHtmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(existingHtmlAttributesObject);
 
         foreach (var item in htmlAttributes)
         {
+            string separator = string.Empty;
             if (keysConcatValuesWithSpace.Contains(item.Key))
             {
-                existingHtmlAttributes.TryGetValue(item.Key, out object? value);
-                if (value != null && item.Value != null)
-                {
-                    existingHtmlAttributes[item.Key] = value != null ?
-                        string.Format("{0} {1}", existingHtmlAttributes[item.Key], item.Value)
-                        : item.Value;
-                }
+                separator = " ";
             }
             else if (keysConcatValuesWithSemiColon.Contains(item.Key))
             {
-                existingHtmlAttributes.TryGetValue(item.Key, out object? value);
-                if (value != null && item.Value != null)
-                {
-                    existingHtmlAttributes[item.Key] = value != null ?
-                        string.Format("{0}; {1}", existingHtmlAttributes[item.Key], item.Value)
-                        : item.Value;
-                }
+                separator = "; ";
             }
-            else
-            {
-                existingHtmlAttributes[item.Key] = item.Value;
-            }
+            existingHtmlAttributes.TryGetValue(item.Key, out object? value);
+            existingHtmlAttributes[item.Key] = value != null && !string.IsNullOrEmpty(separator) ?
+                    string.Format("{0}{1}{2}", existingHtmlAttributes[item.Key], separator, item.Value)
+                    : item.Value;
         }
 
         return existingHtmlAttributes;

--- a/src/TagHelperPack/PublicHtmlHelperExtensions.cs
+++ b/src/TagHelperPack/PublicHtmlHelperExtensions.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Routing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TagHelperPack;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+public static class PublicHtmlHelperExtensions
+{
+    private static IDictionary<string, string> htmlAttributesWithSeparators = new Dictionary<string, string>()
+        {
+            { "class", " "},
+            { "style", "; " },
+        };
+
+    /// <summary>
+    /// Merge values from 2 anonymous or IDictionary objects. Values of overlapping keys from the 'existing values' object are replaced by the values 
+    /// from the 'new values' object except if the keys are 'class' or 'style', in which case the values are concatentated with a space or ; respectively.
+    /// </summary>
+    /// <param name="newHtmlAttributesObject">new values</param>
+    /// <param name="existingHtmlAttributesObject">existing values</param>
+    /// <returns></returns>
+    public static IDictionary<string, object> MergeHtmlAttributesObjects(this IHtmlHelper helper, object newHtmlAttributesObject, object existingHtmlAttributesObject)
+    {
+        IDictionary<string, object> newHtmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(newHtmlAttributesObject);
+        IDictionary<string, object> existingHtmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(existingHtmlAttributesObject);
+
+        foreach (var item in newHtmlAttributes)
+        {
+            htmlAttributesWithSeparators.TryGetValue(item.Key, out string separator);
+
+            existingHtmlAttributes.TryGetValue(item.Key, out object? value);
+
+            if(item.Value != null)
+            {
+                existingHtmlAttributes[item.Key] = value != null && !string.IsNullOrEmpty(separator) ?
+                    string.Format("{0}{1}{2}", existingHtmlAttributes[item.Key], separator, item.Value)
+                    : item.Value;
+            }
+        }
+
+        return existingHtmlAttributes;
+    }
+}


### PR DESCRIPTION
Hi @DamianEdwards 

I would appreciate it if you would review and consider merging these updates into the next version of the library.

1. Updated editor and display tag helpers to accept class and style attributes.
This allows adding classes and styles to the tag helpers as normal html attributes (with IntelliSense support). The values are passed to the editor/display template as an anonymous object on the htmlAttributes property of the ViewData which is how they were passed when using editor templates in MVC5. This allowed me to reuse my existing editor/display templates from MVC5 with minimal changes. I used a modified version of the MergeHtmlAttributes extension created by Chris Pratt.
https://web.archive.org/web/20211205165309/https://cpratt.co/html-editorfor-and-htmlattributes/  (the original site is currently not accessible)

3. Updated AuthzTagHelper to handle authorizations based on User roles and permissions. 
I have updated the TagHelperPack.Sample project to demo these use cases.
a) User role is checked using the Principal.IsInRole() method provided by the framework.
b) Permission is checked in an authorization policy based on the permissions associated with the current user role.